### PR TITLE
zh-CN patch

### DIFF
--- a/source/IdentityServer3.Localization/Constants.cs
+++ b/source/IdentityServer3.Localization/Constants.cs
@@ -12,5 +12,6 @@ namespace Thinktecture.IdentityServer.Core.Services.Contrib
         public const string trTR = "tr-TR";
         public const string roRO = "ro-RO";
         public const string nlNL = "nl-NL";
+        public const string zhCN = "zh-CN";
     }
 }

--- a/source/IdentityServer3.Localization/Internals/LocalizationServiceFactory.cs
+++ b/source/IdentityServer3.Localization/Internals/LocalizationServiceFactory.cs
@@ -23,6 +23,7 @@ namespace Thinktecture.IdentityServer.Core.Services.Contrib.Internals
             AvailableLocalizationServices.Add(CreateResourceBased(Constants.trTR));
             AvailableLocalizationServices.Add(CreateResourceBased(Constants.roRO));
             AvailableLocalizationServices.Add(CreateResourceBased(Constants.nlNL));
+            AvailableLocalizationServices.Add(CreateResourceBased(Constants.zhCN));
         }
 
         public static ILocalizationService Create(LocaleOptions options)

--- a/source/Unittests/AvailableTranslations.cs
+++ b/source/Unittests/AvailableTranslations.cs
@@ -17,6 +17,7 @@ namespace Unittests
         [InlineData("tr-TR")]
         [InlineData("ro-RO")]
         [InlineData("nl-NL")]
+        [InlineData("zh-CN")]
         public void ContainsLocales(string locale)
         {
             Assert.Contains(GlobalizedLocalizationService.GetAvailableLocales(), s => s.Equals(locale));
@@ -25,7 +26,7 @@ namespace Unittests
         [Fact]
         public void HasCorrectCount()
         {
-            Assert.Equal(10, GlobalizedLocalizationService.GetAvailableLocales().Count());
+            Assert.Equal(11, GlobalizedLocalizationService.GetAvailableLocales().Count());
         }
     }
 }


### PR DESCRIPTION
Pre zh-CN support miss some codes.
If the setting of localization is 'zh-CN', application will show error "Localization 'zh-CN' unavailable. Create a Pull Request on GitHub!".
The patch is for fixing this problem.
