### PR TITLE
Support for getting resource based on request headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,19 +13,27 @@ Implementation of IdentityServerV3's ILocalizationService.
 
 - Specific culture:
 ```
-   var options = new LocaleOptions { Locale = "nb-NO" };
-   var localizationService = new GlobalizedLocalizationService(options);
+   var factory = new IdentityServerServiceFactory();
+   var options = new LocaleOptions { LocaleProvider = env => "nb-NO" };
+
+   factory.Register(new Registration<LocaleOptions>(options));   
+   factory.LocalizationService = new Registration<ILocalizationService, GlobalizedLocalizationService>();
 ```
 
-- To use IdentityServer3s default provided localization:
+- To use IdentityServer3s default provided localization fixed:
 ```
-   var localizationService = new GlobalizedLocalizationService();
+   var factory = new IdentityServerServiceFactory();
+   factory.LocalizationService = new Registration<ILocalizationService, GlobalizedLocalizationService>();
 ```
 
-- Pirate culture:
+- To use Pirate culture:
 ```
-   var options = new LocaleOptions { Locale = "pirate" }; // ye be warned!
-   var localizationService = new GlobalizedLocalizationService(options);
+   var factory = new IdentityServerServiceFactory();
+   var options = new LocaleOptions { LocaleProvider = env => "pirate" };
+
+   factory.Register(new Registration<LocaleOptions>(options));   
+   factory.LocalizationService = new Registration<ILocalizationService, GlobalizedLocalizationService>();
+
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,24 @@ Implementation of IdentityServerV3's ILocalizationService.
 
 ```
 
+- Making use of the users language setting:
+```
+  var opts = new LocaleOptions
+  {
+      LocaleProvider = env =>
+      {
+          var owinContext = new OwinContext(env);
+          var owinRequest = owinContext.Request;
+          var headers = owinRequest.Headers;
+          var locale = headers["accept-language"].ToString().Contains("nb") ? "nb-NO" : "es-AR";
+          return locale;
+      }
+  };
+  
+  factory.Register(new Registration<LocaleOptions>(opts));
+  factory.LocalizationService = new Registration<ILocalizationService, GlobalizedLocalizationService>();
+
+```
 
 ## Supported languages
  * See the [live docs of all translations](http://johnkors.github.io/IdentityServer3.Contrib.Localization/#/Default)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@
     only:
       - master
   configuration: Release
-  version: 0.2.{build}
+  version: 0.3.{build}
   assembly_info:
     patch: true
     file: '**\AssemblyInfo.*'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,7 @@
       - dev
 
   configuration: Release
-  version: 0.3.{build}-pre
+  version: 0.3.{build}-beta
   assembly_info:
     patch: true
     file: '**\AssemblyInfo.*'
@@ -57,6 +57,11 @@
   test:
     assemblies:
       - '**\*tests.dll'
+  deploy:
+    provider: NuGet
+    api_key:
+      secure: di77CstF0jvvy/vMgIrYsvrL8ErTWxKbAImcUDdUERD/Zosdta7uM07XuW19vweY
+    artifact: /.*\.nupkg/
 
 # "fall back" configuration for all other branches
 # no "branches" section defined

--- a/source/IdentityServer3.Localization/Constants.cs
+++ b/source/IdentityServer3.Localization/Constants.cs
@@ -2,25 +2,42 @@ namespace IdentityServer3.Core.Services.Contrib
 {
     public class Constants
     {
+
         public const string Default = "Default";
         public const string Pirate = "pirate";
-        public const string deDE = "de-DE";
-        public const string esAR = "es-AR";
-        public const string frFR = "fr-FR";
-        public const string nbNO = "nb-NO";
-        public const string svSE = "sv-SE";
-        public const string trTR = "tr-TR";
-        public const string roRO = "ro-RO";
-        public const string nlNL = "nl-NL";
-        public const string zhCN = "zh-CN";
-        public const string daDK = "da-DK";
-        public const string ruRU = "ru-RU";
-        public const string ptBR = "pt-BR";
-        public const string csCZ = "cs-CZ";
-        public const string itIT = "it-IT";
-        public const string plPL = "pl-PL";
-        public const string skSK = "sk-SK";
+
+
         public const string arSa = "ar-SA";
+
+        public const string csCZ = "cs-CZ";
+
+        public const string deDE = "de-DE";
+        public const string daDK = "da-DK";
+
+        public const string enGB = "en-GB";
+        public const string enUS = "en-US";
+        public const string esES = "es-ES";
+        public const string esAR = "es-AR";
+
         public const string fiFI = "fi-FI";
+        public const string frFR = "fr-FR";
+
+        public const string itIT = "it-IT";
+
+        public const string nbNO = "nb-NO";
+        public const string nlNL = "nl-NL";
+
+        public const string ptBR = "pt-BR";
+        public const string plPL = "pl-PL";
+
+        public const string roRO = "ro-RO";
+        public const string ruRU = "ru-RU";
+
+        public const string skSK = "sk-SK";
+        public const string svSE = "sv-SE";
+
+        public const string trTR = "tr-TR";
+        
+        public const string zhCN = "zh-CN";
     }
 }

--- a/source/IdentityServer3.Localization/GlobalizedLocalizationService.cs
+++ b/source/IdentityServer3.Localization/GlobalizedLocalizationService.cs
@@ -1,4 +1,5 @@
-﻿using IdentityServer3.Core.Services.Contrib.Internals;
+﻿using System;
+using IdentityServer3.Core.Services.Contrib.Internals;
 using System.Collections.Generic;
 
 namespace IdentityServer3.Core.Services.Contrib
@@ -9,9 +10,13 @@ namespace IdentityServer3.Core.Services.Contrib
 
         public GlobalizedLocalizationService(OwinEnvironmentService owinEnvironmentService, LocaleOptions options = null)
         {
+            if (owinEnvironmentService == null)
+            {
+                throw new ArgumentException(@"Cannot be null. Is needed for LocaleProvider Func API. Did you register this service correctly?", "owinEnvironmentService");
+            }
+
             _internalOpts = options ?? new LocaleOptions();
             _internalOpts.EnvironmentService = owinEnvironmentService;
-            _internalOpts.Validate();
         }
 
         public string GetString(string category, string id)

--- a/source/IdentityServer3.Localization/GlobalizedLocalizationService.cs
+++ b/source/IdentityServer3.Localization/GlobalizedLocalizationService.cs
@@ -1,32 +1,23 @@
 ﻿using IdentityServer3.Core.Services.Contrib.Internals;
-using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace IdentityServer3.Core.Services.Contrib
 {
     public class GlobalizedLocalizationService : ILocalizationService
     {
-        private readonly ILocalizationService _service;
+        private readonly LocaleOptions _internalOpts;
 
-        public GlobalizedLocalizationService(LocaleOptions options = null)
+        public GlobalizedLocalizationService(OwinEnvironmentService owinEnvironmentService, LocaleOptions options = null)
         {
-            var internalOpts = options ?? new LocaleOptions();
-            Validate(internalOpts);
-            _service = LocalizationServiceFactory.Create(internalOpts);
-        }
-
-        private void Validate(LocaleOptions options)
-        {
-            if (options.Locale == null || options.Locale.Trim() == string.Empty || !GetAvailableLocales().Contains(options.Locale))
-            {
-                throw new ApplicationException(string.Format("Localization '{0}' unavailable. Create a Pull Request on GitHub!", options.Locale));
-            }
+            _internalOpts = options ?? new LocaleOptions();
+            _internalOpts.EnvironmentService = owinEnvironmentService;
+            _internalOpts.Validate(GetAvailableLocales());
         }
 
         public string GetString(string category, string id)
         {
-            return _service.GetString(category, id);
+            var service = LocalizationServiceFactory.Create(_internalOpts);
+            return service.GetString(category, id);
         }
 
         public static IEnumerable<string> GetAvailableLocales()

--- a/source/IdentityServer3.Localization/GlobalizedLocalizationService.cs
+++ b/source/IdentityServer3.Localization/GlobalizedLocalizationService.cs
@@ -11,7 +11,7 @@ namespace IdentityServer3.Core.Services.Contrib
         {
             _internalOpts = options ?? new LocaleOptions();
             _internalOpts.EnvironmentService = owinEnvironmentService;
-            _internalOpts.Validate(GetAvailableLocales());
+            _internalOpts.Validate();
         }
 
         public string GetString(string category, string id)

--- a/source/IdentityServer3.Localization/IdentityServer3.Localization.csproj
+++ b/source/IdentityServer3.Localization/IdentityServer3.Localization.csproj
@@ -81,6 +81,9 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="Resources\Events\Events.en-GB.resx" />
+    <EmbeddedResource Include="Resources\Events\Events.en-US.resx" />
+    <EmbeddedResource Include="Resources\Events\Events.es-ES.resx" />
     <EmbeddedResource Include="Resources\Events\Events.fi-FI.resx" />
     <EmbeddedResource Include="Resources\Events\Events.ar-SA.resx" />
     <EmbeddedResource Include="Resources\Events\Events.pl-PL.resx" />
@@ -107,7 +110,10 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Resources\Events\Events.tr-TR.resx" />
     <EmbeddedResource Include="Resources\Events\Events.es-AR.resx" />
+    <EmbeddedResource Include="Resources\Messages\Messages.en-GB.resx" />
+    <EmbeddedResource Include="Resources\Messages\Messages.en-US.resx" />
     <EmbeddedResource Include="Resources\Messages\Messages.ar-SA.resx" />
+    <EmbeddedResource Include="Resources\Messages\Messages.es-ES.resx" />
     <EmbeddedResource Include="Resources\Messages\Messages.pl-PL.resx" />
     <EmbeddedResource Include="Resources\Messages\Messages.cs-CZ.resx" />
     <EmbeddedResource Include="Resources\Messages\Messages.it-IT.resx" />
@@ -129,7 +135,10 @@
       <LastGenOutput>Messages.Designer.cs</LastGenOutput>
     </EmbeddedResource>
     <EmbeddedResource Include="Resources\Messages\Messages.tr-TR.resx" />
+    <EmbeddedResource Include="Resources\Scopes\Scopes.en-GB.resx" />
+    <EmbeddedResource Include="Resources\Scopes\Scopes.en-US.resx" />
     <EmbeddedResource Include="Resources\Scopes\Scopes.ar-SA.resx" />
+    <EmbeddedResource Include="Resources\Scopes\Scopes.es-ES.resx" />
     <EmbeddedResource Include="Resources\Scopes\Scopes.pl-PL.resx" />
     <EmbeddedResource Include="Resources\Scopes\Scopes.cs-CZ.resx" />
     <EmbeddedResource Include="Resources\Scopes\Scopes.it-IT.resx" />

--- a/source/IdentityServer3.Localization/Internals/LocalizationServiceFactory.cs
+++ b/source/IdentityServer3.Localization/Internals/LocalizationServiceFactory.cs
@@ -37,7 +37,10 @@ namespace IdentityServer3.Core.Services.Contrib.Internals
 
         public static ILocalizationService Create(LocaleOptions options)
         {
-            var inner = AvailableLocalizationServices[options.Locale];
+            var locale = options.GetLocale();
+       
+            var inner = AvailableLocalizationServices[locale];
+
             if (options.FallbackLocalizationService != null)
             {
                 return new FallbackDecorator(inner, options.FallbackLocalizationService);

--- a/source/IdentityServer3.Localization/Internals/LocalizationServiceFactory.cs
+++ b/source/IdentityServer3.Localization/Internals/LocalizationServiceFactory.cs
@@ -15,24 +15,28 @@ namespace IdentityServer3.Core.Services.Contrib.Internals
                 {Constants.Default, new DefaultLocalizationService()},
                 {Constants.Pirate, new PirateLocalizationService()}
             };
-            AvailableLocalizationServices.Add(CreateResourceBased(Constants.deDE));
-            AvailableLocalizationServices.Add(CreateResourceBased(Constants.esAR));
-            AvailableLocalizationServices.Add(CreateResourceBased(Constants.frFR));
-            AvailableLocalizationServices.Add(CreateResourceBased(Constants.nbNO));
-            AvailableLocalizationServices.Add(CreateResourceBased(Constants.svSE));
-            AvailableLocalizationServices.Add(CreateResourceBased(Constants.trTR));
-            AvailableLocalizationServices.Add(CreateResourceBased(Constants.roRO));
-            AvailableLocalizationServices.Add(CreateResourceBased(Constants.nlNL));
-            AvailableLocalizationServices.Add(CreateResourceBased(Constants.zhCN));
-            AvailableLocalizationServices.Add(CreateResourceBased(Constants.daDK));
-            AvailableLocalizationServices.Add(CreateResourceBased(Constants.ruRU));
-            AvailableLocalizationServices.Add(CreateResourceBased(Constants.ptBR));
-            AvailableLocalizationServices.Add(CreateResourceBased(Constants.csCZ));
-            AvailableLocalizationServices.Add(CreateResourceBased(Constants.plPL));
-            AvailableLocalizationServices.Add(CreateResourceBased(Constants.itIT));
-            AvailableLocalizationServices.Add(CreateResourceBased(Constants.skSK));
+
             AvailableLocalizationServices.Add(CreateResourceBased(Constants.arSa));
+            AvailableLocalizationServices.Add(CreateResourceBased(Constants.csCZ));
+            AvailableLocalizationServices.Add(CreateResourceBased(Constants.deDE));
+            AvailableLocalizationServices.Add(CreateResourceBased(Constants.daDK));
+            AvailableLocalizationServices.Add(CreateResourceBased(Constants.enGB));
+            AvailableLocalizationServices.Add(CreateResourceBased(Constants.enUS));
+            AvailableLocalizationServices.Add(CreateResourceBased(Constants.esAR));
+            AvailableLocalizationServices.Add(CreateResourceBased(Constants.esES));
             AvailableLocalizationServices.Add(CreateResourceBased(Constants.fiFI));
+            AvailableLocalizationServices.Add(CreateResourceBased(Constants.frFR));
+            AvailableLocalizationServices.Add(CreateResourceBased(Constants.itIT));
+            AvailableLocalizationServices.Add(CreateResourceBased(Constants.nbNO));
+            AvailableLocalizationServices.Add(CreateResourceBased(Constants.nlNL));
+            AvailableLocalizationServices.Add(CreateResourceBased(Constants.plPL));
+            AvailableLocalizationServices.Add(CreateResourceBased(Constants.ptBR));
+            AvailableLocalizationServices.Add(CreateResourceBased(Constants.roRO));
+            AvailableLocalizationServices.Add(CreateResourceBased(Constants.ruRU));
+            AvailableLocalizationServices.Add(CreateResourceBased(Constants.svSE));
+            AvailableLocalizationServices.Add(CreateResourceBased(Constants.skSK));
+            AvailableLocalizationServices.Add(CreateResourceBased(Constants.trTR));
+            AvailableLocalizationServices.Add(CreateResourceBased(Constants.zhCN));
         }
 
         public static ILocalizationService Create(LocaleOptions options)

--- a/source/IdentityServer3.Localization/LocaleOptions.cs
+++ b/source/IdentityServer3.Localization/LocaleOptions.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using IdentityServer3.Core.Logging;
 
 namespace IdentityServer3.Core.Services.Contrib
 {
     public class LocaleOptions
     {
+        public static readonly ILog Logger = LogProvider.GetCurrentClassLogger();
         /// <summary>
         /// The localization service to be of use when none is found for the given resouce & locale. Default: english.
         /// </summary>
@@ -29,18 +31,11 @@ namespace IdentityServer3.Core.Services.Contrib
         internal OwinEnvironmentService EnvironmentService { get; set; }
 
 
-        internal void Validate(IEnumerable<string> availableLocales)
+        internal void Validate()
         {
-            var locale = GetLocale();
-            var providedFixedLocaleDoesNotExist = locale == null || locale.Trim() == string.Empty || !availableLocales.Contains(locale);
-            if (providedFixedLocaleDoesNotExist)
+            if (EnvironmentService == null)
             {
-                throw new ApplicationException(string.Format("Localization '{0}' unavailable. Create a Pull Request on GitHub!", locale));
-            }
-
-            if (string.IsNullOrEmpty(locale) && LocaleProvider != null && EnvironmentService == null)
-            {
-                throw new ApplicationException(string.Format("When using the LocaleProvider Func API, you need to provide an OwinEnvironmentService. Was null."));
+                throw new ArgumentException(string.Format("OwinEnvironmentService was null"));
             }
         }
     }

--- a/source/IdentityServer3.Localization/LocaleOptions.cs
+++ b/source/IdentityServer3.Localization/LocaleOptions.cs
@@ -1,13 +1,18 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using IdentityServer3.Core.Logging;
 
 namespace IdentityServer3.Core.Services.Contrib
 {
     public class LocaleOptions
     {
-        public static readonly ILog Logger = LogProvider.GetCurrentClassLogger();
+        public string Locale
+        {
+            set
+            {
+                throw new ApplicationException("Obsolete. Use the new LocaleProvider func instead. opts.LocaleProvider = env => es-ES ");
+            }
+        }
+
         /// <summary>
         /// The localization service to be of use when none is found for the given resouce & locale. Default: english.
         /// </summary>
@@ -29,14 +34,5 @@ namespace IdentityServer3.Core.Services.Contrib
         }
 
         internal OwinEnvironmentService EnvironmentService { get; set; }
-
-
-        internal void Validate()
-        {
-            if (EnvironmentService == null)
-            {
-                throw new ArgumentException(string.Format("OwinEnvironmentService was null"));
-            }
-        }
     }
 }

--- a/source/IdentityServer3.Localization/LocaleOptions.cs
+++ b/source/IdentityServer3.Localization/LocaleOptions.cs
@@ -1,20 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace IdentityServer3.Core.Services.Contrib
 {
     public class LocaleOptions
     {
         /// <summary>
-        /// The Language Culture Name as defined in https://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx
+        /// The localization service to be of use when none is found for the given resouce & locale. Default: english.
         /// </summary>
-        /// <list type="SupportedValues">
-        /// "nb-NO"
-        /// </list>
-        public string Locale { get; set; }
         public ILocalizationService FallbackLocalizationService { get; set; }
 
-        public LocaleOptions()
+        /// <summary>
+        /// A function that resolves a given locale. Is executed for each attempt to get a resource.
+        /// Should return a Language Culture Name as defined in https://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx
+        /// </summary>
+        public Func<IDictionary<string, object>, string> LocaleProvider { get; set; }
+
+        internal string GetLocale()
         {
-            Locale = Constants.Default;
+            if (LocaleProvider != null && EnvironmentService != null)
+            {
+                return LocaleProvider(EnvironmentService.Environment);
+            }
+            return Constants.Default;
+        }
+
+        internal OwinEnvironmentService EnvironmentService { get; set; }
+
+
+        internal void Validate(IEnumerable<string> availableLocales)
+        {
+            var locale = GetLocale();
+            var providedFixedLocaleDoesNotExist = locale == null || locale.Trim() == string.Empty || !availableLocales.Contains(locale);
+            if (providedFixedLocaleDoesNotExist)
+            {
+                throw new ApplicationException(string.Format("Localization '{0}' unavailable. Create a Pull Request on GitHub!", locale));
+            }
+
+            if (string.IsNullOrEmpty(locale) && LocaleProvider != null && EnvironmentService == null)
+            {
+                throw new ApplicationException(string.Format("When using the LocaleProvider Func API, you need to provide an OwinEnvironmentService. Was null."));
+            }
         }
     }
 }

--- a/source/IdentityServer3.Localization/Resources/Events/Events.en-GB.resx
+++ b/source/IdentityServer3.Localization/Resources/Events/Events.en-GB.resx
@@ -1,0 +1,162 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ClientPermissionsRevoked" xml:space="preserve">
+    <value>Client Permissions Revoked</value>
+  </data>
+  <data name="CspReport" xml:space="preserve">
+    <value>Content Security Policy (CSP) Report</value>
+  </data>
+  <data name="ExternalLoginError" xml:space="preserve">
+    <value>External Login Error</value>
+  </data>
+  <data name="ExternalLoginFailure" xml:space="preserve">
+    <value>External Login Failure</value>
+  </data>
+  <data name="ExternalLoginSuccess" xml:space="preserve">
+    <value>External Login Success</value>
+  </data>
+  <data name="LocalLoginFailure" xml:space="preserve">
+    <value>Local Login Failure</value>
+  </data>
+  <data name="LocalLoginSuccess" xml:space="preserve">
+    <value>Local Login Success</value>
+  </data>
+  <data name="LogoutEvent" xml:space="preserve">
+    <value>Logout Event</value>
+  </data>
+  <data name="PartialLogin" xml:space="preserve">
+    <value>Partial Login</value>
+  </data>
+  <data name="PartialLoginComplete" xml:space="preserve">
+    <value>Partial Login Complete</value>
+  </data>
+  <data name="PreLoginFailure" xml:space="preserve">
+    <value>Pre-Login Failure</value>
+  </data>
+  <data name="PreLoginSuccess" xml:space="preserve">
+    <value>Pre-Login Success</value>
+  </data>
+  <data name="ResourceOwnerFlowLoginFailure" xml:space="preserve">
+    <value>Resource Owner Password Flow Login Failure</value>
+  </data>
+  <data name="ResourceOwnerFlowLoginSuccess" xml:space="preserve">
+    <value>Resource Owner Password Flow Login Success</value>
+  </data>
+</root>

--- a/source/IdentityServer3.Localization/Resources/Events/Events.en-US.resx
+++ b/source/IdentityServer3.Localization/Resources/Events/Events.en-US.resx
@@ -1,0 +1,162 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ClientPermissionsRevoked" xml:space="preserve">
+    <value>Client Permissions Revoked</value>
+  </data>
+  <data name="CspReport" xml:space="preserve">
+    <value>Content Security Policy (CSP) Report</value>
+  </data>
+  <data name="ExternalLoginError" xml:space="preserve">
+    <value>External Login Error</value>
+  </data>
+  <data name="ExternalLoginFailure" xml:space="preserve">
+    <value>External Login Failure</value>
+  </data>
+  <data name="ExternalLoginSuccess" xml:space="preserve">
+    <value>External Login Success</value>
+  </data>
+  <data name="LocalLoginFailure" xml:space="preserve">
+    <value>Local Login Failure</value>
+  </data>
+  <data name="LocalLoginSuccess" xml:space="preserve">
+    <value>Local Login Success</value>
+  </data>
+  <data name="LogoutEvent" xml:space="preserve">
+    <value>Logout Event</value>
+  </data>
+  <data name="PartialLogin" xml:space="preserve">
+    <value>Partial Login</value>
+  </data>
+  <data name="PartialLoginComplete" xml:space="preserve">
+    <value>Partial Login Complete</value>
+  </data>
+  <data name="PreLoginFailure" xml:space="preserve">
+    <value>Pre-Login Failure</value>
+  </data>
+  <data name="PreLoginSuccess" xml:space="preserve">
+    <value>Pre-Login Success</value>
+  </data>
+  <data name="ResourceOwnerFlowLoginFailure" xml:space="preserve">
+    <value>Resource Owner Password Flow Login Failure</value>
+  </data>
+  <data name="ResourceOwnerFlowLoginSuccess" xml:space="preserve">
+    <value>Resource Owner Password Flow Login Success</value>
+  </data>
+</root>

--- a/source/IdentityServer3.Localization/Resources/Events/Events.es-ES.resx
+++ b/source/IdentityServer3.Localization/Resources/Events/Events.es-ES.resx
@@ -1,0 +1,162 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ClientPermissionsRevoked" xml:space="preserve">
+    <value>Permisos revocados</value>
+  </data>
+  <data name="CspReport" xml:space="preserve">
+    <value>Reporte de la política de seguridad del contenido (CSP)</value>
+  </data>
+  <data name="ExternalLoginError" xml:space="preserve">
+    <value>Error de Inicio de Sesión Externo</value>
+  </data>
+  <data name="ExternalLoginFailure" xml:space="preserve">
+    <value>Falla en Inicio de Sesión externo</value>
+  </data>
+  <data name="ExternalLoginSuccess" xml:space="preserve">
+    <value>Inicio de Sesión Externo exitoso</value>
+  </data>
+  <data name="LocalLoginFailure" xml:space="preserve">
+    <value>Falla en Inicio de Sesión Local</value>
+  </data>
+  <data name="LocalLoginSuccess" xml:space="preserve">
+    <value>Inicio de Sesión Local Exitoso</value>
+  </data>
+  <data name="LogoutEvent" xml:space="preserve">
+    <value>Evento de Cierre de Sesión</value>
+  </data>
+  <data name="PartialLogin" xml:space="preserve">
+    <value>Inicio Parcial de Sesión</value>
+  </data>
+  <data name="PartialLoginComplete" xml:space="preserve">
+    <value>Inicio Parcial de Sesión Completado </value>
+  </data>
+  <data name="PreLoginFailure" xml:space="preserve">
+    <value>Falla en Pre-inicio de Sesión</value>
+  </data>
+  <data name="PreLoginSuccess" xml:space="preserve">
+    <value>Pre-inicio de Sesión Exitoso</value>
+  </data>
+  <data name="ResourceOwnerFlowLoginFailure" xml:space="preserve">
+    <value>Resource Owner Password Flow Login Faillido</value>
+  </data>
+  <data name="ResourceOwnerFlowLoginSuccess" xml:space="preserve">
+    <value>Resource Owner Password Flow Login Exitoso</value>
+  </data>
+</root>

--- a/source/IdentityServer3.Localization/Resources/Messages/Messages.en-GB.resx
+++ b/source/IdentityServer3.Localization/Resources/Messages/Messages.en-GB.resx
@@ -1,0 +1,177 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ClientIdRequired" xml:space="preserve">
+    <value>Client identifier is required</value>
+  </data>
+  <data name="InvalidUsernameOrPassword" xml:space="preserve">
+    <value>Invalid username or password</value>
+  </data>
+  <data name="invalid_scope" xml:space="preserve">
+    <value>The client application tried to access a resource it does not have access to.</value>
+  </data>
+  <data name="MissingClientId" xml:space="preserve">
+    <value>client_id is missing</value>
+  </data>
+  <data name="MissingToken" xml:space="preserve">
+    <value>Token is missing</value>
+  </data>
+  <data name="MustSelectAtLeastOnePermission" xml:space="preserve">
+    <value>Must select at least one permission.</value>
+  </data>
+  <data name="NoMatchingExternalAccount" xml:space="preserve">
+    <value>Invalid Account</value>
+  </data>
+  <data name="NoSubjectFromExternalProvider" xml:space="preserve">
+    <value>Error authenticating with external provider</value>
+  </data>
+  <data name="PasswordRequired" xml:space="preserve">
+    <value>Password is required</value>
+  </data>
+  <data name="SslRequired" xml:space="preserve">
+    <value>SSL is required</value>
+  </data>
+  <data name="unauthorized_client" xml:space="preserve">
+    <value>The client application is not known or is not authorized.</value>
+  </data>
+  <data name="UnexpectedError" xml:space="preserve">
+    <value>There was an unexpected error</value>
+  </data>
+  <data name="UnsupportedMediaType" xml:space="preserve">
+    <value>Unsupported Media Type</value>
+  </data>
+  <data name="unsupported_response_type" xml:space="preserve">
+    <value>The authorization server does not support the requested response type.</value>
+  </data>
+  <data name="UsernameRequired" xml:space="preserve">
+    <value>Username is required</value>
+  </data>
+  <data name="NoSignInCookie" xml:space="preserve">
+    <value>There is an error determining which application you are signing into. Return to the application and try again.</value>
+  </data>
+  <data name="NoExternalProvider" xml:space="preserve">
+    <value>The external login provider was not provided.</value>
+  </data>
+  <data name="ExternalProviderError" xml:space="preserve">
+    <value>There was an error logging into the external provider. The error message is: {0}</value>
+  </data>
+  <data name="invalid_request" xml:space="preserve">
+    <value>The client application made an invalid request.</value>
+  </data>
+</root>

--- a/source/IdentityServer3.Localization/Resources/Messages/Messages.en-US.resx
+++ b/source/IdentityServer3.Localization/Resources/Messages/Messages.en-US.resx
@@ -1,0 +1,177 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ClientIdRequired" xml:space="preserve">
+    <value>Client identifier is required</value>
+  </data>
+  <data name="InvalidUsernameOrPassword" xml:space="preserve">
+    <value>Invalid username or password</value>
+  </data>
+  <data name="invalid_scope" xml:space="preserve">
+    <value>The client application tried to access a resource it does not have access to.</value>
+  </data>
+  <data name="MissingClientId" xml:space="preserve">
+    <value>client_id is missing</value>
+  </data>
+  <data name="MissingToken" xml:space="preserve">
+    <value>Token is missing</value>
+  </data>
+  <data name="MustSelectAtLeastOnePermission" xml:space="preserve">
+    <value>Must select at least one permission.</value>
+  </data>
+  <data name="NoMatchingExternalAccount" xml:space="preserve">
+    <value>Invalid Account</value>
+  </data>
+  <data name="NoSubjectFromExternalProvider" xml:space="preserve">
+    <value>Error authenticating with external provider</value>
+  </data>
+  <data name="PasswordRequired" xml:space="preserve">
+    <value>Password is required</value>
+  </data>
+  <data name="SslRequired" xml:space="preserve">
+    <value>SSL is required</value>
+  </data>
+  <data name="unauthorized_client" xml:space="preserve">
+    <value>The client application is not known or is not authorized.</value>
+  </data>
+  <data name="UnexpectedError" xml:space="preserve">
+    <value>There was an unexpected error</value>
+  </data>
+  <data name="UnsupportedMediaType" xml:space="preserve">
+    <value>Unsupported Media Type</value>
+  </data>
+  <data name="unsupported_response_type" xml:space="preserve">
+    <value>The authorization server does not support the requested response type.</value>
+  </data>
+  <data name="UsernameRequired" xml:space="preserve">
+    <value>Username is required</value>
+  </data>
+  <data name="NoSignInCookie" xml:space="preserve">
+    <value>There is an error determining which application you are signing into. Return to the application and try again.</value>
+  </data>
+  <data name="NoExternalProvider" xml:space="preserve">
+    <value>The external login provider was not provided.</value>
+  </data>
+  <data name="ExternalProviderError" xml:space="preserve">
+    <value>There was an error logging into the external provider. The error message is: {0}</value>
+  </data>
+  <data name="invalid_request" xml:space="preserve">
+    <value>The client application made an invalid request.</value>
+  </data>
+</root>

--- a/source/IdentityServer3.Localization/Resources/Messages/Messages.es-ES.resx
+++ b/source/IdentityServer3.Localization/Resources/Messages/Messages.es-ES.resx
@@ -1,0 +1,177 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ClientIdRequired" xml:space="preserve">
+    <value>El identificador del cliente es obligatorio</value>
+  </data>
+  <data name="InvalidUsernameOrPassword" xml:space="preserve">
+    <value>Usuario o clave erroneo.</value>
+  </data>
+  <data name="invalid_scope" xml:space="preserve">
+    <value>La aplicación cliente intentó acceder a un recurso al que no tiene acceso.</value>
+  </data>
+  <data name="MissingClientId" xml:space="preserve">
+    <value>client_id no encontrado</value>
+  </data>
+  <data name="MissingToken" xml:space="preserve">
+    <value>Token no encontrado</value>
+  </data>
+  <data name="MustSelectAtLeastOnePermission" xml:space="preserve">
+    <value>Debe seleccionar al menos un permiso.</value>
+  </data>
+  <data name="NoMatchingExternalAccount" xml:space="preserve">
+    <value>Cuenta Inválida</value>
+  </data>
+  <data name="NoSubjectFromExternalProvider" xml:space="preserve">
+    <value>Error al intentar auntenticarse con el proveedor externo</value>
+  </data>
+  <data name="PasswordRequired" xml:space="preserve">
+    <value>La clave es obligatoria</value>
+  </data>
+  <data name="SslRequired" xml:space="preserve">
+    <value>SSL es necesario</value>
+  </data>
+  <data name="unauthorized_client" xml:space="preserve">
+    <value>La aplicación cliente es desconocia o no está autorizada.</value>
+  </data>
+  <data name="UnexpectedError" xml:space="preserve">
+    <value>Ha ocurrido un error inesperado</value>
+  </data>
+  <data name="UnsupportedMediaType" xml:space="preserve">
+    <value>Tipo de medios no soportado.</value>
+  </data>
+  <data name="unsupported_response_type" xml:space="preserve">
+    <value>El servidor de autorización no soporta el tipo de respuesta solicitado.</value>
+  </data>
+  <data name="UsernameRequired" xml:space="preserve">
+    <value>El nombre de usuario es obligatorio</value>
+  </data>
+  <data name="NoSignInCookie" xml:space="preserve">
+    <value>Ha ocurrido un error determinado en cuál aplicación esta intentando iniciar sesión. Regrese a la aplicación e intente nuevamente.</value>
+  </data>
+  <data name="NoExternalProvider" xml:space="preserve">
+    <value>El proveedor externo no fue proporcionado.</value>
+  </data>
+  <data name="ExternalProviderError" xml:space="preserve">
+    <value>Ha ocurrido un error al iniciar sesión en el proveedor externo. El mensaje de error es: {0}</value>
+  </data>
+  <data name="invalid_request" xml:space="preserve">
+    <value>La aplicación cliente ha realizado una solicitud inválida.</value>
+  </data>
+</root>

--- a/source/IdentityServer3.Localization/Resources/Scopes/Scopes.en-GB.resx
+++ b/source/IdentityServer3.Localization/Resources/Scopes/Scopes.en-GB.resx
@@ -1,0 +1,147 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="address_DisplayName" xml:space="preserve">
+    <value>Your postal address</value>
+  </data>
+  <data name="all_claims_DisplayName" xml:space="preserve">
+    <value>All user information</value>
+  </data>
+  <data name="email_DisplayName" xml:space="preserve">
+    <value>Your email address</value>
+  </data>
+  <data name="offline_access_DisplayName" xml:space="preserve">
+    <value>Offline access</value>
+  </data>
+  <data name="openid_DisplayName" xml:space="preserve">
+    <value>Your user identifier</value>
+  </data>
+  <data name="phone_DisplayName" xml:space="preserve">
+    <value>Your phone number</value>
+  </data>
+  <data name="profile_Description" xml:space="preserve">
+    <value>Your user profile information (first name, last name, etc.)</value>
+  </data>
+  <data name="profile_DisplayName" xml:space="preserve">
+    <value>User profile</value>
+  </data>
+  <data name="roles_DisplayName" xml:space="preserve">
+    <value>User roles</value>
+  </data>
+</root>

--- a/source/IdentityServer3.Localization/Resources/Scopes/Scopes.en-US.resx
+++ b/source/IdentityServer3.Localization/Resources/Scopes/Scopes.en-US.resx
@@ -1,0 +1,147 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="address_DisplayName" xml:space="preserve">
+    <value>Your postal address</value>
+  </data>
+  <data name="all_claims_DisplayName" xml:space="preserve">
+    <value>All user information</value>
+  </data>
+  <data name="email_DisplayName" xml:space="preserve">
+    <value>Your email address</value>
+  </data>
+  <data name="offline_access_DisplayName" xml:space="preserve">
+    <value>Offline access</value>
+  </data>
+  <data name="openid_DisplayName" xml:space="preserve">
+    <value>Your user identifier</value>
+  </data>
+  <data name="phone_DisplayName" xml:space="preserve">
+    <value>Your phone number</value>
+  </data>
+  <data name="profile_Description" xml:space="preserve">
+    <value>Your user profile information (first name, last name, etc.)</value>
+  </data>
+  <data name="profile_DisplayName" xml:space="preserve">
+    <value>User profile</value>
+  </data>
+  <data name="roles_DisplayName" xml:space="preserve">
+    <value>User roles</value>
+  </data>
+</root>

--- a/source/IdentityServer3.Localization/Resources/Scopes/Scopes.es-ES.resx
+++ b/source/IdentityServer3.Localization/Resources/Scopes/Scopes.es-ES.resx
@@ -1,0 +1,147 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="address_DisplayName" xml:space="preserve">
+    <value>Su codigo postal</value>
+  </data>
+  <data name="all_claims_DisplayName" xml:space="preserve">
+    <value>Toda la información del usuario</value>
+  </data>
+  <data name="email_DisplayName" xml:space="preserve">
+    <value>Su email</value>
+  </data>
+  <data name="offline_access_DisplayName" xml:space="preserve">
+    <value>Acceso fuera de linea</value>
+  </data>
+  <data name="openid_DisplayName" xml:space="preserve">
+    <value>Su identificador de usuario</value>
+  </data>
+  <data name="phone_DisplayName" xml:space="preserve">
+    <value>Su número telefónico</value>
+  </data>
+  <data name="profile_Description" xml:space="preserve">
+    <value>Su información de perfil  (nombre, apellido, etc.)</value>
+  </data>
+  <data name="profile_DisplayName" xml:space="preserve">
+    <value>Perfil de usuario</value>
+  </data>
+  <data name="roles_DisplayName" xml:space="preserve">
+    <value>Roles de usuario</value>
+  </data>
+</root>

--- a/source/Unittests/AvailableTranslations.cs
+++ b/source/Unittests/AvailableTranslations.cs
@@ -9,24 +9,27 @@ namespace Unittests
         [Theory]
         [InlineData("Default")]
         [InlineData("pirate")]
+        [InlineData("ar-SA")]
+        [InlineData("cs-CZ")]
         [InlineData("de-DE")]
+        [InlineData("da-DK")]
+        [InlineData("en-GB")]
+        [InlineData("en-US")]
         [InlineData("es-AR")]
+        [InlineData("es-ES")]
+        [InlineData("fi-FI")]
         [InlineData("fr-FR")]
+        [InlineData("it-IT")]
         [InlineData("nb-NO")]
+        [InlineData("nl-NL")]
+        [InlineData("pl-PL")]
+        [InlineData("pt-BR")]
+        [InlineData("ro-RO")]
+        [InlineData("ru-RU")]
+        [InlineData("sk-SK")]
         [InlineData("sv-SE")]
         [InlineData("tr-TR")]
-        [InlineData("ro-RO")]
-        [InlineData("nl-NL")]
         [InlineData("zh-CN")]
-        [InlineData("da-DK")]
-        [InlineData("ru-RU")]
-        [InlineData("pt-BR")]
-        [InlineData("cs-CZ")]
-        [InlineData("it-IT")]
-        [InlineData("pl-PL")]
-        [InlineData("sk-SK")]
-        [InlineData("ar-SA")]
-        [InlineData("fi-FI")]
         public void ContainsLocales(string locale)
         {
             Assert.Contains(GlobalizedLocalizationService.GetAvailableLocales(), s => s.Equals(locale));
@@ -35,7 +38,7 @@ namespace Unittests
         [Fact]
         public void HasCorrectCount()
         {
-            Assert.Equal(20, GlobalizedLocalizationService.GetAvailableLocales().Count());
+            Assert.Equal(23, GlobalizedLocalizationService.GetAvailableLocales().Count());
         }
     }
 }

--- a/source/Unittests/TheService.cs
+++ b/source/Unittests/TheService.cs
@@ -54,7 +54,7 @@ namespace Unittests
         [Theory]
         [InlineData("")]
         [InlineData("notexisting")]
-        public void ThrowsExceptionForUnknownLocales(string locale)
+        public void DoesNotThrowsExceptionForUnknownLocales(string locale)
         {
             var options = new LocaleOptions
             {
@@ -63,7 +63,9 @@ namespace Unittests
 
             var envServiceMock = new Fake<OwinEnvironmentService>().FakedObject;
 
-            Assert.Throws<ApplicationException>(() => new GlobalizedLocalizationService(envServiceMock, options));
+            var service = new GlobalizedLocalizationService(envServiceMock, options);
+
+            //var dontCare = service.GetString(IdSrvConstants.Messages, MessageIds.MissingClientId);
         }
 
         [Fact]


### PR DESCRIPTION
# Breaking changes:

Before:

```
var factory = new IdentityServerServiceFactory();
var options = new LocaleOptions { Locale = "pirate" }; // ye be warned!
var localizationService = new GlobalizedLocalizationService(options);
factory.LocalizationService = new Registration<ILocalizationService, GlobalizedLocalizationService>(localizationService);
```

Now:

```
var factory = new IdentityServerServiceFactory();
var options = new LocaleOptions { LocaleProvider = env => "pirate" };

factory.Register(new Registration<LocaleOptions>(options));   
factory.LocalizationService = new Registration<ILocalizationService, GlobalizedLocalizationService>();
```
## NEW. Added feature:

Defer localization choice until request is made:

```
using System.Net.Http.Headers; // StringWithQualityHeaderValue

..

var opts = new LocaleOptions
  {
      LocaleProvider = env =>
      {
          var owinContext = new OwinContext(env);
          var owinRequest = owinContext.Request;
          var headers = owinRequest.Headers;
          var accept_language_header = headers["accept-language"].ToString();
          var languages = accept_language_header.Split(',')
                                          .Select(StringWithQualityHeaderValue.Parse)
                                          .OrderByDescending(s => s.Quality.GetValueOrDefault(1));
         var locale = languages.First().Value;
         return locale;
      }
  };
```
