### PR TITLE
Gracefully handle LocaleProvider func returning null

### DIFF
--- a/source/IdentityServer3.Localization/Internals/LocalizationServiceFactory.cs
+++ b/source/IdentityServer3.Localization/Internals/LocalizationServiceFactory.cs
@@ -12,6 +12,11 @@ namespace IdentityServer3.Core.Services.Contrib.Internals
         {
             var locale = options.GetLocale(env);
 
+            if (string.IsNullOrWhiteSpace(locale))
+            {
+                locale = Constants.enUS;
+            }
+
             var isLanguage = locale.Length == 2;
             if (isLanguage)
             {

--- a/source/IdentityServer3.Localization/Internals/LocalizationServiceFactory.cs
+++ b/source/IdentityServer3.Localization/Internals/LocalizationServiceFactory.cs
@@ -12,11 +12,6 @@ namespace IdentityServer3.Core.Services.Contrib.Internals
         {
             var locale = options.GetLocale(env);
 
-            if (string.IsNullOrWhiteSpace(locale))
-            {
-                locale = Constants.enUS;
-            }
-
             var isLanguage = locale.Length == 2;
             if (isLanguage)
             {

--- a/source/IdentityServer3.Localization/LocaleOptions.cs
+++ b/source/IdentityServer3.Localization/LocaleOptions.cs
@@ -33,7 +33,12 @@ namespace IdentityServer3.Core.Services.Contrib
 
         internal string GetLocale(IDictionary<string, object> env)
         {
-            var locale = LocaleProvider?.Invoke(env);
+            if (LocaleProvider == null)
+            {
+                return Constants.enUS;
+            }
+
+            var locale = LocaleProvider(env);
 
             if (string.IsNullOrWhiteSpace(locale))
             {

--- a/source/IdentityServer3.Localization/LocaleOptions.cs
+++ b/source/IdentityServer3.Localization/LocaleOptions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using IdentityServer3.Core.Services.Default;
 
@@ -6,12 +6,12 @@ namespace IdentityServer3.Core.Services.Contrib
 {
     public class LocaleOptions
     {
-
         public LocaleOptions()
         {
             FallbackLocalizationService = new DefaultLocalizationService();
         }
 
+        [Obsolete]
         public string Locale
         {
             set
@@ -33,12 +33,14 @@ namespace IdentityServer3.Core.Services.Contrib
 
         internal string GetLocale(IDictionary<string, object> env)
         {
-            if (LocaleProvider != null )
+            var locale = LocaleProvider?.Invoke(env);
+
+            if (string.IsNullOrWhiteSpace(locale))
             {
-                return LocaleProvider(env);
+                return Constants.enUS;
             }
-            return Constants.enUS;
+
+            return locale;
         }
-        
     }
 }

--- a/source/IdentityServer3.Localization/Properties/AssemblyInfo.cs
+++ b/source/IdentityServer3.Localization/Properties/AssemblyInfo.cs
@@ -34,5 +34,3 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-
-[assembly: InternalsVisibleTo("Unittests")]

--- a/source/IdentityServer3.Localization/Properties/AssemblyInfo.cs
+++ b/source/IdentityServer3.Localization/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -33,3 +34,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+[assembly: InternalsVisibleTo("Unittests")]

--- a/source/Unittests/TheService.cs
+++ b/source/Unittests/TheService.cs
@@ -99,6 +99,23 @@ namespace Unittests
             var dontCare = service.GetString(IdSrvConstants.Messages, MessageIds.MissingClientId);
         }
 
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void GetLocaleReturnsDefaultWhenLocaleProviderReturnsNullOrWhitespace(string locale)
+        {
+            var options = new LocaleOptions
+            {
+                LocaleProvider = env => locale
+            };
+
+            var envServiceMock = new Fake<OwinEnvironmentService>().FakedObject;
+
+            var result = options.GetLocale(envServiceMock.Environment);
+
+            Assert.Equal("en-US", result);
+        }
+
         [Fact]
         public void FetchesResourceWhenUsingLocaleProviderFunc()
         {

--- a/source/Unittests/TheService.cs
+++ b/source/Unittests/TheService.cs
@@ -99,23 +99,6 @@ namespace Unittests
             var dontCare = service.GetString(IdSrvConstants.Messages, MessageIds.MissingClientId);
         }
 
-        [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        public void GetLocaleReturnsDefaultWhenLocaleProviderReturnsNullOrWhitespace(string locale)
-        {
-            var options = new LocaleOptions
-            {
-                LocaleProvider = env => locale
-            };
-
-            var envServiceMock = new Fake<OwinEnvironmentService>().FakedObject;
-
-            var result = options.GetLocale(envServiceMock.Environment);
-
-            Assert.Equal("en-US", result);
-        }
-
         [Fact]
         public void FetchesResourceWhenUsingLocaleProviderFunc()
         {

--- a/source/Unittests/TheService.cs
+++ b/source/Unittests/TheService.cs
@@ -82,6 +82,7 @@ namespace Unittests
         }
 
         [Theory]
+		[InlineData(null)]
         [InlineData("")]
         [InlineData("notexisting")]
         public void DoesNotThrowsExceptionForUnknownLocales(string locale)

--- a/source/Unittests/TheService.cs
+++ b/source/Unittests/TheService.cs
@@ -85,7 +85,7 @@ namespace Unittests
 		[InlineData(null)]
         [InlineData("")]
         [InlineData("notexisting")]
-        public void DoesNotThrowsExceptionForUnknownLocales(string locale)
+        public void UnknownLocalesUseDefaultLocale(string locale)
         {
             var options = new LocaleOptions
             {
@@ -96,7 +96,9 @@ namespace Unittests
 
             var service = new GlobalizedLocalizationService(envServiceMock, options);
 
-            var dontCare = service.GetString(IdSrvConstants.Messages, MessageIds.MissingClientId);
+            var resource = service.GetString(IdSrvConstants.Messages, MessageIds.MissingClientId);
+
+            Assert.Equal("client_id is missing", resource);
         }
 
         [Fact]


### PR DESCRIPTION
Gracefully handle the case where the LocaleProvider func returns null (defaults to en-US)
