### PR TITLE
Fix typo for InvalidUsernameOrPassword message in nb-NO

### DIFF
--- a/source/IdentityServer3.Localization/Resources/Messages/Messages.nb-NO.resx
+++ b/source/IdentityServer3.Localization/Resources/Messages/Messages.nb-NO.resx
@@ -127,7 +127,7 @@
     <value>Ugyldig scope</value>
   </data>
   <data name="InvalidUsernameOrPassword" xml:space="preserve">
-    <value>Ugyldig brukerernavn eller passord</value>
+    <value>Ugyldig brukernavn eller passord</value>
   </data>
   <data name="MissingClientId" xml:space="preserve">
     <value>ClientId mangler</value>


### PR DESCRIPTION
Hello,

this change fixes a minor typo for the `InvalidUsernameOrPassword` message for nb-NO.

All tests were green :)
