### PR TITLE
Brazilian portuguese pt-BR improvements

### DIFF
--- a/source/IdentityServer3.Localization/Resources/Events/Events.pt-BR.resx
+++ b/source/IdentityServer3.Localization/Resources/Events/Events.pt-BR.resx
@@ -142,16 +142,16 @@
     <value>Evento de logout</value>
   </data>
   <data name="PartialLogin" xml:space="preserve">
-    <value>Logon Parcial</value>
+    <value>Logon parcial</value>
   </data>
   <data name="PartialLoginComplete" xml:space="preserve">
-    <value>Logon Parcial completo</value>
+    <value>Logon parcial completo</value>
   </data>
   <data name="PreLoginFailure" xml:space="preserve">
-    <value>Falha no Pré-Logon</value>
+    <value>Falha no pré-logon</value>
   </data>
   <data name="PreLoginSuccess" xml:space="preserve">
-    <value>Sucesso no Pré-Logon</value>
+    <value>Sucesso no pré-logon</value>
   </data>
   <data name="ResourceOwnerFlowLoginFailure" xml:space="preserve">
     <value>O logon usando fluxo Resource Owner falhou</value>

--- a/source/IdentityServer3.Localization/Resources/Events/Events.pt-BR.resx
+++ b/source/IdentityServer3.Localization/Resources/Events/Events.pt-BR.resx
@@ -154,9 +154,9 @@
     <value>Sucesso no Pré-Login</value>
   </data>
   <data name="ResourceOwnerFlowLoginFailure" xml:space="preserve">
-    <value>Falha de logon com fluxo de recurso proprietário e senha </value>
+    <value>O logon usando fluxo Resource Owner falhou</value>
   </data>
   <data name="ResourceOwnerFlowLoginSuccess" xml:space="preserve">
-    <value>Sucesso no login com fluxo de recurso proprietário e senha </value>
+    <value>Login usando fluxo Resource Owner feito com sucesso</value>
   </data>
 </root>

--- a/source/IdentityServer3.Localization/Resources/Events/Events.pt-BR.resx
+++ b/source/IdentityServer3.Localization/Resources/Events/Events.pt-BR.resx
@@ -124,13 +124,13 @@
     <value>Relatório de política de segurança de conteúdo (CSP)</value>
   </data>
   <data name="ExternalLoginError" xml:space="preserve">
-    <value>Erro no login externo</value>
+    <value>Erro no logon externo</value>
   </data>
   <data name="ExternalLoginFailure" xml:space="preserve">
-    <value>Falha no login externo</value>
+    <value>Falha no logon externo</value>
   </data>
   <data name="ExternalLoginSuccess" xml:space="preserve">
-    <value>Sucesso no login externo</value>
+    <value>Sucesso no logon externo</value>
   </data>
   <data name="LocalLoginFailure" xml:space="preserve">
     <value>Falha no logon local</value>
@@ -142,21 +142,21 @@
     <value>Evento de logout</value>
   </data>
   <data name="PartialLogin" xml:space="preserve">
-    <value>Login Parcial</value>
+    <value>Logon Parcial</value>
   </data>
   <data name="PartialLoginComplete" xml:space="preserve">
-    <value>Login Parcial completo</value>
+    <value>Logon Parcial completo</value>
   </data>
   <data name="PreLoginFailure" xml:space="preserve">
-    <value>Falha no Pré-Login</value>
+    <value>Falha no Pré-Logon</value>
   </data>
   <data name="PreLoginSuccess" xml:space="preserve">
-    <value>Sucesso no Pré-Login</value>
+    <value>Sucesso no Pré-Logon</value>
   </data>
   <data name="ResourceOwnerFlowLoginFailure" xml:space="preserve">
     <value>O logon usando fluxo Resource Owner falhou</value>
   </data>
   <data name="ResourceOwnerFlowLoginSuccess" xml:space="preserve">
-    <value>Login usando fluxo Resource Owner feito com sucesso</value>
+    <value>Logon usando fluxo Resource Owner feito com sucesso</value>
   </data>
 </root>

--- a/source/IdentityServer3.Localization/Resources/Messages/Messages.pt-BR.resx
+++ b/source/IdentityServer3.Localization/Resources/Messages/Messages.pt-BR.resx
@@ -118,22 +118,22 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ClientIdRequired" xml:space="preserve">
-    <value>Identificador do cliente é necessário</value>
+    <value>O identificador do cliente é necessário</value>
   </data>
   <data name="ExternalProviderError" xml:space="preserve">
     <value>Há um log de erro do provedor externo. A mensagem de erro: {0}</value>
   </data>
   <data name="invalid_request" xml:space="preserve">
-    <value>O aplicativo cliente fez um pedido inválido.</value>
+    <value>O aplicativo cliente fez uma requisição inválida.</value>
   </data>
   <data name="invalid_scope" xml:space="preserve">
     <value>O aplicativo cliente tentou acessar um recurso que não tem acesso.</value>
   </data>
   <data name="InvalidUsernameOrPassword" xml:space="preserve">
-    <value>Nome de usuário ou senha inválido</value>
+    <value>Nome de usuário ou senha inválidos</value>
   </data>
   <data name="MissingClientId" xml:space="preserve">
-    <value>client_id está faltando</value>
+    <value>O client_id está faltando</value>
   </data>
   <data name="MissingToken" xml:space="preserve">
     <value>O token está faltando</value>
@@ -154,7 +154,7 @@
     <value>Erro de autenticação com o provedor externo</value>
   </data>
   <data name="PasswordRequired" xml:space="preserve">
-    <value>Senha é necessária</value>
+    <value>A senha é necessária</value>
   </data>
   <data name="SslRequired" xml:space="preserve">
     <value>SSL é necessário</value>
@@ -172,6 +172,6 @@
     <value>Tipo de mídia (Media Type) não suportado</value>
   </data>
   <data name="UsernameRequired" xml:space="preserve">
-    <value>Nome de usuário é necessária</value>
+    <value>O nome de usuário é necessário</value>
   </data>
 </root>

--- a/source/IdentityServer3.Localization/Resources/Messages/Messages.pt-BR.resx
+++ b/source/IdentityServer3.Localization/Resources/Messages/Messages.pt-BR.resx
@@ -148,7 +148,7 @@
     <value>Conta inválida</value>
   </data>
   <data name="NoSignInCookie" xml:space="preserve">
-    <value>Há um erro ao determinar qual aplicativo você está assinando. Retorne para o aplicativo e tente novamente.</value>
+    <value>Há um erro ao determinar em qual aplicativo você está logando. Retorne para o aplicativo e tente novamente.</value>
   </data>
   <data name="NoSubjectFromExternalProvider" xml:space="preserve">
     <value>Erro de autenticação com o provedor externo</value>

--- a/source/IdentityServer3.Localization/Resources/Scopes/Scopes.pt-BR.resx
+++ b/source/IdentityServer3.Localization/Resources/Scopes/Scopes.pt-BR.resx
@@ -142,6 +142,6 @@
     <value>Perfil de usuário</value>
   </data>
   <data name="roles_DisplayName" xml:space="preserve">
-    <value>Funções de usuário</value>
+    <value>Cargos do usuário</value>
   </data>
 </root>


### PR DESCRIPTION
Made some improvements in portuguese translation.

Major issues:
- [Wrong translation of *signing*](https://github.com/johnkors/IdentityServer3.Contrib.Localization/pull/64/commits/bc58f9e797ba83176d58e09fa618ddbd189d20e7)

Minor issues:
- Use a constructs closer to what is used in a daily basis in portuguese which the users are more used to.
- Fix some unusual casing. In portuguese messages are not written with a capital first letter so often (as it is in english or even more in german).
- Rolled back translation of some technical expressions, like *Resource Owner* which has its meaning dimmed when translated. Brazilians uses foreign words thorougly.